### PR TITLE
Bundle to one build file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,17 +3,15 @@
   "version": "1.0.0",
   "description": "",
   "main": "meter-usage.js",
+  "type": "module",
   "scripts": {
-    "build": "babel src --out-file build/app.js --ignore 'src/**/*.test.js'",
+    "build": "rollup -c",
     "test": "jest"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@babel/cli": "^7.23.9",
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-modules-commonjs": "^7.23.0",
-    "@babel/preset-env": "^7.23.2",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "rollup": "^4.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,17 +4,16 @@
   "description": "",
   "main": "meter-usage.js",
   "scripts": {
-    "build": "./node_modules/.bin/babel src --out-file build/app.js --ignore 'src/**/*.test.js'",
+    "build": "babel src --out-file build/app.js --ignore 'src/**/*.test.js'",
     "test": "jest"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@babel/cli": "^7.23.9",
     "@babel/core": "^7.23.2",
     "@babel/plugin-transform-modules-commonjs": "^7.23.0",
     "@babel/preset-env": "^7.23.2",
-    "babel-cli": "^6.26.0",
-    "babel-jest": "^29.7.0",
     "jest": "^29.7.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,8 @@
+export default {
+    input: 'src/macros.js',
+    output: {
+        file: 'build/main.js',
+        format: 'cjs',
+        sourceMap: 'inline'
+    }
+};

--- a/src/actions/auto-fill-range.js
+++ b/src/actions/auto-fill-range.js
@@ -31,7 +31,7 @@ export class AutoFillRange {
 
     selectedRange.autoFill(
       this.sheet.getRange(fillRange),
-      this.sheet.AutoFillSeries.DEFAULT_SERIES
+      SpreadsheetApp.AutoFillSeries.DEFAULT_SERIES
     );
   }
 }

--- a/src/macros.js
+++ b/src/macros.js
@@ -2,11 +2,11 @@
 
 import { OnEditValidations } from './validations/on-edit-validations';
 import { ClearRange } from './actions/clear-range';
-import { populateCalculatedRow } from './populate-calculated-row';
+import { populateCalculatedRow } from './meter-usage';
 
 const restoreActiveCell = e => e.range.offset(1, 0).activate();
 
-function onEdit(e) {
+export const onEdit = (e) => {
   const onEditValidations = new OnEditValidations(e);
   if (onEditValidations.shouldPopulateCells()) {
     populateCalculatedRow(e, restoreActiveCell);
@@ -14,7 +14,7 @@ function onEdit(e) {
 
   if (onEditValidations.shouldDeleteCells()) {
     const row = e.range.getRow();
-    const clearRange = new ClearRange(e.soure);
+    const clearRange = new ClearRange(e.source);
     clearRange.call(`C${row}:G${row}`);
   }
 }

--- a/src/meter-usage.js
+++ b/src/meter-usage.js
@@ -1,6 +1,7 @@
 import { FindFirstEmptyRow } from './find/first-empty-row';
 import { AutoFillRange } from './actions/auto-fill-range';
 import { FillMeterReadingAverage } from './actions/fill-meter-reading-average';
+import { SelectRange } from "./actions/select-range.js";
 
 export const populateCalculatedRow = (e, callback) => {
   const cell = e.range;


### PR DESCRIPTION
There are various bugs in the app, and it compiles to a version of ECMA Script that Google App Scripts doesn't understand.

I tried various iterations with Babel, but each presented its own compatability issues with Google App Scripts. The main one being that even though it compiled it down to one file, there were still `exports` in the code file which Google App Scripts does not understand. To address this, I used `rollup` instead which removes all of the exports except for the one headline `onEdit` function, rollup still requires to compile. The only change required to copy / paste the code to google app scripts is to remove the last module.exports line.

There is one failing spec file which needs fixing. Will address later.